### PR TITLE
added to UpperCase and split camel case for Modal Key

### DIFF
--- a/client/src/components/SharedModal.tsx
+++ b/client/src/components/SharedModal.tsx
@@ -21,7 +21,7 @@ function SharedModal({ opened, setOpened, request, buttons, responderID, setResp
     for (const [key, value] of Object.entries(details)) {
       requestDetails.push(
         <Fragment key={key}>
-          <Text ta="right">{key}</Text>
+          <Text ta="right">{key.replace(/([a-z](?=[A-Z]))/g, '$1 ').toUpperCase()}</Text>
           <Text ta="left">{value}</Text>
         </Fragment>,
       )

--- a/client/src/requestor/Form.tsx
+++ b/client/src/requestor/Form.tsx
@@ -135,7 +135,7 @@ const Form = (props: FormProps) => {
     for (const [key, value] of Object.entries(details)) {
       requestDetails.push(
         <Fragment key={key}>
-          <Text ta="right">{key}</Text>
+          <Text ta="right">{key.replace(/([a-z](?=[A-Z]))/g, '$1 ').toUpperCase()}</Text>
           <Text ta="left">{value}</Text>
         </Fragment>,
       )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "9-line-medevac",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "server",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
closes #66 

fixed naming convention of key in Components/SharedModal and Requestor/Form/Modal